### PR TITLE
Workaround for mono

### DIFF
--- a/src/EFCore.Relational/Extensions/Internal/DbConnectionExtensions.cs
+++ b/src/EFCore.Relational/Extensions/Internal/DbConnectionExtensions.cs
@@ -18,17 +18,21 @@ namespace System.Data.Common
                 .GetMethod("BeginTransactionAsync", new[] { typeof(IsolationLevel), typeof(CancellationToken) });
             if (beginTransactionAsync != null)
             {
-                var connection = Expression.Parameter(typeof(DbConnection), "connection");
-                var isolationLevel = Expression.Parameter(typeof(IsolationLevel), "isolationLevel");
-                var cancellationToken = Expression.Parameter(typeof(CancellationToken), "cancellationToken");
-
-                _beginTransactionAsync = Expression
-                    .Lambda<Func<DbConnection, IsolationLevel, CancellationToken, ValueTask<DbTransaction>>>(
-                        Expression.Call(connection, beginTransactionAsync, isolationLevel, cancellationToken),
-                        connection,
-                        isolationLevel,
-                        cancellationToken)
-                    .Compile();
+                // var connection = Expression.Parameter(typeof(DbConnection), "connection");
+                // var isolationLevel = Expression.Parameter(typeof(IsolationLevel), "isolationLevel");
+                // var cancellationToken = Expression.Parameter(typeof(CancellationToken), "cancellationToken");
+                //
+                // _beginTransactionAsync = Expression
+                //     .Lambda<Func<DbConnection, IsolationLevel, CancellationToken, ValueTask<DbTransaction>>>(
+                //         Expression.Call(connection, beginTransactionAsync, isolationLevel, cancellationToken),
+                //         connection,
+                //         isolationLevel,
+                //         cancellationToken)
+                //     .Compile();
+                _beginTransactionAsync = (connection, level, cancellationToken) =>
+                {
+                    return (ValueTask<DbTransaction>)beginTransactionAsync.Invoke(connection, new object[] { level, cancellationToken });
+                };
             }
             else
             {
@@ -38,11 +42,12 @@ namespace System.Data.Common
             var closeAsync = typeof(DbConnection).GetMethod("CloseAsync", Type.EmptyTypes);
             if (closeAsync != null)
             {
-                var connection = Expression.Parameter(typeof(DbConnection), "connection");
-
-                _closeAsync = Expression
-                    .Lambda<Func<DbConnection, Task>>(Expression.Call(connection, closeAsync), connection)
-                    .Compile();
+                // var connection = Expression.Parameter(typeof(DbConnection), "connection");
+                //
+                // _closeAsync = Expression
+                //     .Lambda<Func<DbConnection, Task>>(Expression.Call(connection, closeAsync), connection)
+                //     .Compile();
+                _closeAsync = connection => (Task)closeAsync.Invoke(connection, Array.Empty<object>());
             }
             else
             {

--- a/src/EFCore/Infrastructure/ExpressionExtensions.cs
+++ b/src/EFCore/Infrastructure/ExpressionExtensions.cs
@@ -70,7 +70,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             if (memberExpression.Member is FieldInfo fieldInfo
                 && fieldInfo.IsInitOnly)
             {
-                if (new FrameworkName(AppContext.TargetFrameworkName).Identifier == ".NETFramework")
+                // if (new FrameworkName(AppContext.TargetFrameworkName).Identifier == ".NETFramework")
+                if (true)
                 {
                     // On .NET Framework the compiler refuses to compile an expression tree with IsInitOnly access,
                     // so use Reflection's SetValue instead.
@@ -83,12 +84,12 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                             typeof(object)));
                 }
 
-                return (BinaryExpression)Activator.CreateInstance(
-                    _assignBinaryExpressionType,
-                    BindingFlags.NonPublic | BindingFlags.Instance,
-                    null,
-                    new object[] { memberExpression, valueExpression },
-                    null);
+                // return (BinaryExpression)Activator.CreateInstance(
+                //     _assignBinaryExpressionType,
+                //     BindingFlags.NonPublic | BindingFlags.Instance,
+                //     null,
+                //     new object[] { memberExpression, valueExpression },
+                //     null);
             }
 
             return Expression.Assign(memberExpression, valueExpression);


### PR DESCRIPTION
- https://github.com/mono/mono/issues/20996 Two conflicting ValueTask<T> implementations
    - In cctor, using ValueTask in ExpressionTree causes runtime error.
    - I simply replace to reflection
- AppContext.TargetFramework return null
    - Commented out where this is used.
